### PR TITLE
Add permanent DOKS capacity for Argo CD

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -18,6 +18,6 @@ resource "digitalocean_kubernetes_cluster" "wp-blogs" {
   node_pool {
     name       = "wp-blogs-nodes"
     size       = "s-1vcpu-2gb"
-    node_count = 3
+    node_count = 4
   }
 }


### PR DESCRIPTION
## Summary
- increase the existing production node pool from three to four s-1vcpu-2gb nodes
- reserve capacity for the non-HA Argo CD phase 1 control plane
- keep Kubernetes, provider, and workload versions unchanged

## Validation
- Terraform provider extraction with no parse errors
- terraform fmt -check -recursive
- terraform validate
- Checkov with no findings
- terraform-validator regression suite
- complete staged diff review
- Gitleaks with redacted output

## Cost
- expected recurring DigitalOcean increase: USD 12/month, reverified before apply

## Safety
- merge does not apply Terraform
- the exact saved HCP Terraform plan requires separate approval