### PR TITLE
Fix ApplicationSet CRD server-side apply

### DIFF
--- a/clusters/prod/README.md
+++ b/clusters/prod/README.md
@@ -39,8 +39,18 @@ have remained healthy for at least seven days.
 ## Initial reconciliation posture
 
 Every Application starts in manual-sync mode. Automated sync, pruning,
-self-healing, Force, Replace, and global server-side apply are intentionally
-absent. ApplicationSet deletion preserves deployed resources.
+self-healing, Force, Replace, and application-wide or global server-side apply
+are intentionally absent. ApplicationSet deletion preserves deployed resources.
+
+`CustomResourceDefinition/applicationsets.argoproj.io` is the sole
+server-side-apply exception because its OpenAPI schema exceeds Kubernetes'
+client-side last-applied annotation limit. Initial bootstrap applies that CRD
+separately with `kubectl apply --server-side --force-conflicts`; all remaining
+bootstrap resources continue to use ordinary client-side apply. During later
+Argo self-management, only that CRD carries
+`argocd.argoproj.io/sync-options: ServerSideApply=true`. Do not add this sync
+option to an Application, ApplicationSet, AppProject, another resource, or a
+global policy.
 
 Live adoption is sequential:
 
@@ -85,5 +95,6 @@ Run the local validation gate from the repository root:
 
 The script uses private temporary Helm homes and renders, checks Helm 3/4
 parity, validates schemas, rejects duplicate resource identities, enforces the
-WordPress and sync-policy boundaries, verifies ciphertext-only secret handling,
+WordPress and sync-policy boundaries, requires exactly one server-side-apply
+annotation on the ApplicationSet CRD, verifies ciphertext-only secret handling,
 and confirms the legacy Flux sources remain tracked.

--- a/clusters/prod/bootstrap/argocd/config-patches/applicationset-crd-ssa.yaml
+++ b/clusters/prod/bootstrap/argocd/config-patches/applicationset-crd-ssa.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: applicationsets.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true

--- a/clusters/prod/bootstrap/argocd/kustomization.yaml
+++ b/clusters/prod/bootstrap/argocd/kustomization.yaml
@@ -12,3 +12,4 @@ patches:
   - path: config-patches/argocd-rbac-cm.yaml
   - path: config-patches/workload-resources.yaml
   - path: config-patches/dex-disabled.yaml
+  - path: config-patches/applicationset-crd-ssa.yaml

--- a/scripts/validate-gitops.sh
+++ b/scripts/validate-gitops.sh
@@ -235,6 +235,7 @@ validate_scope_boundaries() {
 
 validate_server_side_apply_exception() {
   local exception_file="clusters/prod/bootstrap/argocd/config-patches/applicationset-crd-ssa.yaml"
+  local applicationset_crd_count
   local source_ssa_count
   local rendered_targets
   local -a managed_paths=(
@@ -262,6 +263,18 @@ validate_server_side_apply_exception() {
   )
   [[ "${source_ssa_count}" == "1" ]] ||
     die "Expected exactly one source SSA exception; found ${source_ssa_count}"
+
+  applicationset_crd_count=$(
+    "${YQ_BIN}" eval-all -r -N '
+      select(
+        .kind == "CustomResourceDefinition" and
+        .metadata.name == "applicationsets.argoproj.io"
+      ) |
+      .metadata.name
+    ' "${render_dir}/bootstrap.yaml" | /usr/bin/awk 'END { print NR }'
+  )
+  [[ "${applicationset_crd_count}" == "1" ]] ||
+    die "Expected exactly one rendered ApplicationSet CRD; found ${applicationset_crd_count}"
 
   rendered_targets=$(
     "${YQ_BIN}" eval-all -r -N '

--- a/scripts/validate-gitops.sh
+++ b/scripts/validate-gitops.sh
@@ -236,6 +236,7 @@ validate_scope_boundaries() {
 validate_server_side_apply_exception() {
   local exception_file="clusters/prod/bootstrap/argocd/config-patches/applicationset-crd-ssa.yaml"
   local applicationset_crd_count
+  local exception_document_count
   local source_ssa_count
   local rendered_targets
   local -a managed_paths=(
@@ -245,6 +246,13 @@ validate_server_side_apply_exception() {
   )
 
   [[ -f "${exception_file}" ]] || die "Required ApplicationSet CRD SSA exception is missing"
+
+  exception_document_count=$(
+    "${YQ_BIN}" -r -N '"document"' "${exception_file}" |
+      /usr/bin/awk 'END { print NR }'
+  )
+  [[ "${exception_document_count}" == "1" ]] ||
+    die "ApplicationSet CRD SSA patch must contain exactly one YAML document; found ${exception_document_count}"
 
   "${YQ_BIN}" -e '
     .apiVersion == "apiextensions.k8s.io/v1" and

--- a/scripts/validate-gitops.sh
+++ b/scripts/validate-gitops.sh
@@ -227,10 +227,50 @@ validate_scope_boundaries() {
   fi
 
   if "${GREP_BIN}" -R -n -E \
-    'automated:|prune:[[:space:]]*true|selfHeal:[[:space:]]*true|Force=true|Replace=true|ServerSideApply=true' \
+    'automated:|prune:[[:space:]]*true|selfHeal:[[:space:]]*true|Force=true|Replace=true' \
     "${managed_paths[@]}"; then
     die "Unsafe automatic or destructive sync configuration detected"
   fi
+}
+
+validate_server_side_apply_exception() {
+  local exception_file="clusters/prod/bootstrap/argocd/config-patches/applicationset-crd-ssa.yaml"
+  local source_ssa_count
+  local rendered_targets
+  local -a managed_paths=(
+    clusters/prod/bootstrap
+    clusters/prod/control-plane
+    clusters/prod/platform
+  )
+
+  [[ -f "${exception_file}" ]] || die "Required ApplicationSet CRD SSA exception is missing"
+
+  "${YQ_BIN}" -e '
+    .apiVersion == "apiextensions.k8s.io/v1" and
+    .kind == "CustomResourceDefinition" and
+    .metadata.name == "applicationsets.argoproj.io" and
+    .metadata.annotations."argocd.argoproj.io/sync-options" == "ServerSideApply=true" and
+    ((keys | sort | join(",")) == "apiVersion,kind,metadata") and
+    ((.metadata | keys | sort | join(",")) == "annotations,name") and
+    ((.metadata.annotations | keys | join(",")) == "argocd.argoproj.io/sync-options")
+  ' "${exception_file}" >/dev/null || die "ApplicationSet CRD SSA patch has unexpected content"
+
+  source_ssa_count=$(
+    {
+      "${GREP_BIN}" -R -h -o -F 'ServerSideApply=true' "${managed_paths[@]}" || true
+    } | /usr/bin/awk 'END { print NR }'
+  )
+  [[ "${source_ssa_count}" == "1" ]] ||
+    die "Expected exactly one source SSA exception; found ${source_ssa_count}"
+
+  rendered_targets=$(
+    "${YQ_BIN}" eval-all -r -N '
+      select(.metadata.annotations."argocd.argoproj.io/sync-options" == "ServerSideApply=true") |
+      [.apiVersion, .kind, (.metadata.namespace // ""), .metadata.name] | @tsv
+    ' "${render_dir}/bootstrap.yaml"
+  )
+  [[ "${rendered_targets}" == $'apiextensions.k8s.io/v1\tCustomResourceDefinition\t\tapplicationsets.argoproj.io' ]] ||
+    die "SSA exception rendered on an unexpected resource: ${rendered_targets:-none}"
 }
 
 validate_repository_access() {
@@ -346,6 +386,7 @@ main() {
   validate_unique_identities
   validate_applicationset
   validate_scope_boundaries
+  validate_server_side_apply_exception
   validate_repository_access
   validate_secret_boundaries
   validate_preserved_sources


### PR DESCRIPTION
## Summary

- apply server-side apply only to the ApplicationSet CRD
- enforce the single source patch, single patch document, single rendered CRD, and exact annotated target
- document the separate bootstrap and Argo self-management behavior

## Validation

- scripts/validate-gitops.sh
- Bash syntax, ShellCheck, and custom script checks
- duplicate-CRD and multi-document negative fixtures
- Gitleaks branch-range and working-tree scans
- independent whole-branch review with no remaining findings

## Scope

Repository-only change. This PR does not install Argo CD, synchronize Applications, adopt services, or mutate the live cluster.