### PR TITLE
fix: patch existing Argo CD secret from SealedSecret

### DIFF
--- a/clusters/prod/bootstrap/argocd/local-accounts-sealedsecret.yaml
+++ b/clusters/prod/bootstrap/argocd/local-accounts-sealedsecret.yaml
@@ -5,8 +5,6 @@ metadata:
   creationTimestamp: null
   name: argocd-secret
   namespace: argocd
-  annotations:
-    sealedsecrets.bitnami.com/patch: "true"
 spec:
   encryptedData:
     accounts.break-glass.password: AgAO/k8XEORT/E8UCv8CcoRwK7lvu5salYObY8fTRx1jFtbhOWaFufn/iAqV64vc8wJBNvCLK9pA7u4jyd1B1TbPazSZPhQveRszWuOL3Wb0Qkg+ILjdG4X1ebBVfr/ary5jjnBpHLXh12EEn15ItKKWqGcFdVshisGFjkwvGeFvGKYFrt+zo0W3TeHNt0RD28sbmyyGejOEqbVvEx7YkkL86gCV11sJRGb4lUMxCQLuf2QlYrSHqHPowrC/s6RJgpJgId7nlFkP5+hM9+wg0RrUWL9rkHPsnq83JXfzGNfqvToe1exxT0yrCR3leFA4qDu6a7QFHOyooBw5hOuepAjoTKO/WfLAeSUh8edJbUOzlK8UU/JH7ECpEOY+fNddv+4/dB2MjBfNrJMpPXBkYWnvRufIs180V+5EVL6MozvGvborRckuxMcPez3sp/MtARCgTeuVXzKpjhrsvO0yiRZsO3c/k+wFQl4zmBNivaYx/i6gmeqAuOD/WiztkDGHrJb/WIT7Oe7XLRunjhhrdJP+wSU5WMOyJNK+YrlRvntsxOu/JFIJb33IY5L8G0eY0q7F3jJV3Wh56MMifeqpipqPViYT/CA4kmSLfP0TDOd2EkUxwRMKCDFe7w84REj19Jl6mPV8C1u4NvhBcOnY/W4CCmgEUJUYFYoMzKL+4Kg7u1pEiRbxMOZuxkMUd0vqtSeC92IOOSz25c54hlIAO+e6S/PqcOzao1CCrqVCRA47WEcq2QpNpvRBA93FIHq2/vCLPoieFeJjLnuGrzU=
@@ -15,5 +13,7 @@ spec:
     accounts.douglas.passwordMtime: AgCNzZ4GBmSBIHSSTpj4mdHanRkxFyJiuY+A8duZJ3DUh77KutXizlzLaMqrN1k5pFSXnNZTZ6MP4oewZgh9GqgJnIj8BTjJ8IgmPJti7meYkXwceiH0UGkenAENKrRWgsYe/Osvi2XN6pn4+8fB2smg27cJ0mlMTCCAMdeNNLqiki525Me5pOTCIAz4VivB0q24EtcQzI2cIH9zwByMtwMevnCYAsryQ6izGN4wJl3CnN8MoFKtcpsk4vAJAwqw4XsQ4O4vmLcrTuo6nXYWuinCsrTtTjrJgHbc0QHm9IUZqnUz7M3jEUc8qyFgsdBU89fdBc2NK+w2NwXwUsJmXrGtRBsS59W09S3+0EzJEYXKoZ4b5FnkRcPZM0cI2q4LPuVVowMDBXGiDevoXalktx7f2ll5Bb+wd+W8yBN2aGhjDeNruRV+49n+AKEuHTKYzc2xWWYqvtoBQIClPCL1ytkOmldrsCbXRxWKIgcFqXJ/518jQEOjss1TmGRaz4yYLLI0dEL3hnp2QSPbM45qWKlBvW/6jU2ILHEOHmmhRHaTgD2yCTgVgJ6yKVFm4NvdQLgvfVGrGnaSJPLlqegX4C6jRgDXag8M7FIg964qIbkOPhGOgDqC1Ui8ojuemgOo8NHeXzSkwZZP8bXA2rsZcgOlXQw+6sFy33DRQidrZBnZVdFfpsZaI/rv3qnq24kbFlefFJY9zx7aMU3EA5jNXww2okZFd+s=
   template:
     metadata:
+      annotations:
+        sealedsecrets.bitnami.com/patch: "true"
       name: argocd-secret
       namespace: argocd

--- a/scripts/validate-gitops.sh
+++ b/scripts/validate-gitops.sh
@@ -331,6 +331,17 @@ validate_repository_access() {
 validate_secret_boundaries() {
   local rendered_secret_violations
   local sealed_secret_violations
+  local account_sealed_secret="clusters/prod/bootstrap/argocd/local-accounts-sealedsecret.yaml"
+
+  "${YQ_BIN}" -e '
+    .apiVersion == "bitnami.com/v1alpha1" and
+    .kind == "SealedSecret" and
+    .metadata.name == "argocd-secret" and
+    .metadata.namespace == "argocd" and
+    .metadata.annotations."sealedsecrets.bitnami.com/patch" == null and
+    .spec.template.metadata.annotations."sealedsecrets.bitnami.com/patch" == "true"
+  ' "${account_sealed_secret}" >/dev/null ||
+    die "argocd-secret SealedSecret must place patch annotation on generated Secret template"
 
   rendered_secret_violations=$(
     "${YQ_BIN}" eval-all -r -N \


### PR DESCRIPTION
## Summary

- place the Sealed Secrets patch annotation on the generated Secret template
- add a validation invariant that rejects the previous annotation placement
- preserve all encrypted account data unchanged

## Validation

- observed the new semantic assertion fail against the previous manifest
- `scripts/validate-gitops.sh`
- `git diff --cached --check`
- Gitleaks staged scan with redacted output

## Scope

This PR changes repository configuration only. It does not bootstrap Argo CD or mutate the production cluster.