### PR TITLE
Fix existing Argo Secret patch annotation

### DIFF
--- a/clusters/prod/bootstrap/argocd/config-patches/argocd-secret-patch.yaml
+++ b/clusters/prod/bootstrap/argocd/config-patches/argocd-secret-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-secret
+  annotations:
+    sealedsecrets.bitnami.com/patch: "true"

--- a/clusters/prod/bootstrap/argocd/kustomization.yaml
+++ b/clusters/prod/bootstrap/argocd/kustomization.yaml
@@ -10,6 +10,7 @@ patches:
   - path: config-patches/argocd-cm.yaml
   - path: config-patches/argocd-cmd-params-cm.yaml
   - path: config-patches/argocd-rbac-cm.yaml
+  - path: config-patches/argocd-secret-patch.yaml
   - path: config-patches/workload-resources.yaml
   - path: config-patches/dex-disabled.yaml
   - path: config-patches/applicationset-crd-ssa.yaml

--- a/scripts/validate-gitops.sh
+++ b/scripts/validate-gitops.sh
@@ -330,8 +330,24 @@ validate_repository_access() {
 
 validate_secret_boundaries() {
   local rendered_secret_violations
+  local rendered_secret_patch_targets
   local sealed_secret_violations
   local account_sealed_secret="clusters/prod/bootstrap/argocd/local-accounts-sealedsecret.yaml"
+  local account_secret_patch="clusters/prod/bootstrap/argocd/config-patches/argocd-secret-patch.yaml"
+
+  [[ -f "${account_secret_patch}" ]] ||
+    die "Required argocd-secret Secret patch is missing"
+
+  "${YQ_BIN}" -e '
+    .apiVersion == "v1" and
+    .kind == "Secret" and
+    .metadata.name == "argocd-secret" and
+    .metadata.annotations."sealedsecrets.bitnami.com/patch" == "true" and
+    ((keys | sort | join(",")) == "apiVersion,kind,metadata") and
+    ((.metadata | keys | sort | join(",")) == "annotations,name") and
+    ((.metadata.annotations | keys | join(",")) == "sealedsecrets.bitnami.com/patch")
+  ' "${account_secret_patch}" >/dev/null ||
+    die "argocd-secret Secret patch has unexpected content"
 
   "${YQ_BIN}" -e '
     .apiVersion == "bitnami.com/v1alpha1" and
@@ -342,6 +358,15 @@ validate_secret_boundaries() {
     .spec.template.metadata.annotations."sealedsecrets.bitnami.com/patch" == "true"
   ' "${account_sealed_secret}" >/dev/null ||
     die "argocd-secret SealedSecret must place patch annotation on generated Secret template"
+
+  rendered_secret_patch_targets=$(
+    "${YQ_BIN}" eval-all -r -N '
+      select(.metadata.annotations."sealedsecrets.bitnami.com/patch" == "true") |
+      [.apiVersion, .kind, (.metadata.namespace // ""), .metadata.name] | @tsv
+    ' "${render_dir}/bootstrap.yaml"
+  )
+  [[ "${rendered_secret_patch_targets}" == $'v1\tSecret\targocd\targocd-secret' ]] ||
+    die "Patch annotation rendered on an unexpected Secret target: ${rendered_secret_patch_targets:-none}"
 
   rendered_secret_violations=$(
     "${YQ_BIN}" eval-all -r -N \


### PR DESCRIPTION
## Summary
- annotate the upstream-rendered `argocd-secret` before Sealed Secrets reconciliation
- retain the template annotation so patch behavior remains declared on the generated Secret
- add regression coverage for the exact source patch and rendered target

## Validation
- `bash -n scripts/validate-gitops.sh`
- `shellcheck scripts/validate-gitops.sh`
- `scripts/validate-gitops.sh`
- focused Kustomize/yq Secret annotation check
- encrypted SealedSecret data parity check
- staged Gitleaks scan

This pull request changes repository configuration only. It does not bootstrap Argo CD or mutate the production cluster.