### PR TITLE
fix(argocd): bound repo-server memory use

### DIFF
--- a/clusters/prod/bootstrap/argocd/config-patches/argocd-cmd-params-cm.yaml
+++ b/clusters/prod/bootstrap/argocd/config-patches/argocd-cmd-params-cm.yaml
@@ -3,4 +3,5 @@ kind: ConfigMap
 metadata:
   name: argocd-cmd-params-cm
 data:
+  reposerver.parallelism.limit: "1"
   server.insecure: "true"

--- a/clusters/prod/bootstrap/argocd/config-patches/workload-resources.yaml
+++ b/clusters/prod/bootstrap/argocd/config-patches/workload-resources.yaml
@@ -81,7 +81,7 @@ spec:
               memory: 128Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 768Mi
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/scripts/validate-gitops.sh
+++ b/scripts/validate-gitops.sh
@@ -213,6 +213,27 @@ validate_applicationset() {
     clusters/prod/control-plane/platform-applicationset.yaml >/dev/null
 }
 
+validate_repo_server_safety() {
+  local cmd_params_file="clusters/prod/bootstrap/argocd/config-patches/argocd-cmd-params-cm.yaml"
+  local workload_resources_file="clusters/prod/bootstrap/argocd/config-patches/workload-resources.yaml"
+  local repo_server_memory_limit
+
+  "${YQ_BIN}" -e '.data."reposerver.parallelism.limit" == "1"' \
+    "${cmd_params_file}" >/dev/null ||
+    die "Argo CD repo-server parallelism must be limited to one manifest generation"
+
+  repo_server_memory_limit=$(
+    "${YQ_BIN}" eval-all -r '
+      select(.kind == "Deployment" and .metadata.name == "argocd-repo-server") |
+      .spec.template.spec.containers[] |
+      select(.name == "argocd-repo-server") |
+      .resources.limits.memory
+    ' "${workload_resources_file}"
+  )
+  [[ "${repo_server_memory_limit}" == "768Mi" ]] ||
+    die "Argo CD repo-server memory limit must be 768Mi"
+}
+
 validate_scope_boundaries() {
   local -a managed_paths=(
     clusters/prod/bootstrap
@@ -428,6 +449,8 @@ main() {
 
   check_tools
   cd "${REPO_ROOT}"
+
+  validate_repo_server_safety
 
   render_dir=$(mktemp -d "${TMPDIR:-/tmp}/blogs-gitops-validation.XXXXXX")
   mkdir -p "${render_dir}/helm3" "${render_dir}/helm4"


### PR DESCRIPTION
## Summary

- limit repo-server manifest generation to one concurrent request
- raise only the repo-server memory limit from 512Mi to 768Mi
- add regression assertions for both safety settings

## Incident evidence

The initial GitOps control-plane reconciliation generated seven manifest requests in one second. The repo-server had no configured parallelism limit and was OOMKilled at its 512Mi container limit. The node had no memory pressure, and application automation remained disabled.

## Validation

- test-first regression checks failed on the missing parallelism cap and then the 512Mi limit
- scripts/validate-gitops.sh
- Bash syntax, ShellCheck, and custom validator checks
- Kustomize rendered-value assertions
- kubeconform: 62 resources, 57 valid, 0 invalid, 5 intentionally skipped
- Gitleaks staged scan: no leaks