### PR TITLE
fix(argocd): make repo-server rollout single-node safe

### DIFF
--- a/clusters/prod/bootstrap/argocd/config-patches/workload-resources.yaml
+++ b/clusters/prod/bootstrap/argocd/config-patches/workload-resources.yaml
@@ -71,6 +71,11 @@ kind: Deployment
 metadata:
   name: argocd-repo-server
 spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     spec:
       containers:

--- a/scripts/validate-gitops.sh
+++ b/scripts/validate-gitops.sh
@@ -232,6 +232,14 @@ validate_repo_server_safety() {
   )
   [[ "${repo_server_memory_limit}" == "768Mi" ]] ||
     die "Argo CD repo-server memory limit must be 768Mi"
+
+  "${YQ_BIN}" eval-all -e '
+    select(.kind == "Deployment" and .metadata.name == "argocd-repo-server") |
+    .spec.strategy.type == "RollingUpdate" and
+    .spec.strategy.rollingUpdate.maxSurge == 0 and
+    .spec.strategy.rollingUpdate.maxUnavailable == 1
+  ' "${workload_resources_file}" >/dev/null ||
+    die "Argo CD repo-server rollout must avoid surge and allow one unavailable replica"
 }
 
 validate_scope_boundaries() {


### PR DESCRIPTION
## Summary
- persist the in-place repo-server rollout setting with zero surge and one unavailable replica
- add regression coverage for the exact rollout strategy

## Validation
- ./scripts/validate-gitops.sh
- deterministic Bash validator: syntax, ShellCheck, and custom checks
- focused Kustomize render assertion for strategy and unchanged resources
- redacted Gitleaks staged scan

## Live state
The production repo-server Deployment already has these exact rollout values and is Ready. This PR only removes Git drift; it does not authorize or perform a cluster sync.