### PR TITLE
Enable DOKS capacity autoscaling

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,9 +15,16 @@ resource "digitalocean_kubernetes_cluster" "wp-blogs" {
   region  = "nyc1"
   version = "1.36.3-do.0"
 
+  cluster_autoscaler_configuration {
+    scale_down_utilization_threshold = 0.65
+    scale_down_unneeded_time         = "10m0s"
+  }
+
   node_pool {
     name       = "wp-blogs-nodes"
     size       = "s-1vcpu-2gb"
-    node_count = 4
+    auto_scale = true
+    min_nodes  = 4
+    max_nodes  = 5
   }
 }


### PR DESCRIPTION
## Summary

- enable DOKS node pool autoscaling between four and five nodes
- use a 65% scale-down utilization threshold and 10-minute unneeded window
- retain the current four-node minimum while allowing one temporary burst node

## Validation

- terraform fmt -check -recursive
- terraform validate -no-color
- Checkov: no findings
- Gitleaks staged scan: no leaks